### PR TITLE
Handle null values in stats

### DIFF
--- a/src/uti.ts
+++ b/src/uti.ts
@@ -130,14 +130,14 @@ export const formatStatsTable = (stats: Stats): string => {
   const tableSeparator =
     '|' + Array.from({ length: 4 }, () => ':---:|').join('');
   const lastRatings = [
-    stats.chess_rapid.last?.rating,
-    stats.chess_blitz.last?.rating,
-    stats.chess_bullet.last?.rating
+    stats.chess_rapid?.last?.rating ?? 'No Rating',
+    stats.chess_blitz?.last?.rating ?? 'No Rating',
+    stats.chess_bullet?.last?.rating ?? 'No Rating'
   ];
   const bestRatings = [
-    stats.chess_rapid.best?.rating,
-    stats.chess_blitz.best?.rating,
-    stats.chess_bullet.best?.rating
+    stats.chess_rapid?.best?.rating ?? 'No Rating',
+    stats.chess_blitz?.best?.rating ?? 'No Rating',
+    stats.chess_bullet?.best?.rating ?? 'No Rating'
   ];
   const lastRatingRow = `| Current | ${lastRatings.join(' | ')} |`;
   const bestRatingRow = `| Best | ${bestRatings.join(' | ')} |`;

--- a/src/uti.ts
+++ b/src/uti.ts
@@ -130,14 +130,14 @@ export const formatStatsTable = (stats: Stats): string => {
   const tableSeparator =
     '|' + Array.from({ length: 4 }, () => ':---:|').join('');
   const lastRatings = [
-    stats.chess_rapid.last.rating,
-    stats.chess_blitz.last.rating,
-    stats.chess_bullet.last.rating
+    stats.chess_rapid.last?.rating,
+    stats.chess_blitz.last?.rating,
+    stats.chess_bullet.last?.rating
   ];
   const bestRatings = [
-    stats.chess_rapid.best.rating,
-    stats.chess_blitz.best.rating,
-    stats.chess_bullet.best.rating
+    stats.chess_rapid.best?.rating,
+    stats.chess_blitz.best?.rating,
+    stats.chess_bullet.best?.rating
   ];
   const lastRatingRow = `| Current | ${lastRatings.join(' | ')} |`;
   const bestRatingRow = `| Best | ${bestRatings.join(' | ')} |`;


### PR DESCRIPTION
The chess user may or may not have games on specific category, ex: blitz, bullet, rapid. For example, I don't have bullet's best game but have others. In this case your actions fails with nullity access error.

![image](https://user-images.githubusercontent.com/3758212/189127939-be69122e-1022-4ed6-81e9-b47386873478.png)
